### PR TITLE
Make `clippy` (mostly) happy

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -30,7 +30,7 @@ use std::{
 
 use crate::{
     codecs::{NativeU32, ZeroCopyCodec},
-    error::{DbError, GetDocumentError, SearchError},
+    error::{DatabaseError, DocumentError, SearchError},
     normalize,
     roaringish::{Aligned, ArchivedBorrowRoaringishPacked, RoaringishPackedKind, Unaligned},
     stats::Stats,
@@ -233,19 +233,19 @@ impl<D> Document for D where
 {
 }
 
-pub struct DB<D: Document> {
+pub struct Db<D: Document> {
     pub env: Env,
     db_main: Database<Unspecified, Unspecified>,
     db_doc_id_to_document: Database<NativeU32, ZeroCopyCodec<D>>,
     db_token_to_offsets: Database<Str, ZeroCopyCodec<Offset>>,
 }
 
-unsafe impl<D: Document> Send for DB<D> {}
+unsafe impl<D: Document> Send for Db<D> {}
 
-unsafe impl<D: Document> Sync for DB<D> {}
+unsafe impl<D: Document> Sync for Db<D> {}
 
-impl<D: Document> DB<D> {
-    pub fn truncate<P: AsRef<Path>>(path: P, db_size: usize) -> Result<Self, DbError> {
+impl<D: Document> Db<D> {
+    pub fn truncate<P: AsRef<Path>>(path: P, db_size: usize) -> Result<Self, DatabaseError> {
         let path = path.as_ref();
         let _ = std::fs::remove_dir_all(path);
         std::fs::create_dir_all(path)?;
@@ -287,7 +287,7 @@ impl<D: Document> DB<D> {
         rwtxn: &mut RwTxn,
         doc_ids: &[u32],
         documents: &[D],
-    ) -> Result<(), DbError> {
+    ) -> Result<(), DatabaseError> {
         log::debug!("Writing documents");
         let b = std::time::Instant::now();
         for (doc_id, document) in doc_ids.iter().zip(documents.iter()) {
@@ -304,7 +304,7 @@ impl<D: Document> DB<D> {
         token_id_to_roaringish_packed: &[RoaringishPacked],
         mmap_size: &mut usize,
         batch_id: u32,
-    ) -> Result<(), DbError> {
+    ) -> Result<(), DatabaseError> {
         log::debug!("Writing token to roaringish packed");
         let b = std::time::Instant::now();
         let mut token_to_packed: Vec<_> = token_to_token_id
@@ -337,7 +337,7 @@ impl<D: Document> DB<D> {
         mmap_size: usize,
         number_of_batches: u32,
         rwtxn: &mut RwTxn,
-    ) -> Result<(), DbError> {
+    ) -> Result<(), DatabaseError> {
         #[inline(always)]
         unsafe fn write_to_mmap<const N: usize>(
             mmap: &mut MmapMut,
@@ -374,14 +374,14 @@ impl<D: Document> DB<D> {
 
         // we need to do this in 3 steps because of the borrow checker
         let files_mmaps = (0..number_of_batches)
-            .map(|i| -> Result<Mmap, DbError> {
+            .map(|i| -> Result<Mmap, DatabaseError> {
                 let file_name = format!("{}_{i}", db_constants::TEMP_FILE_TOKEN_TO_PACKED);
                 let file = File::options()
                     .read(true)
                     .open(self.env.path().join(file_name))?;
                 unsafe { Ok(Mmap::map(&file)?) }
             })
-            .collect::<Result<Vec<_>, DbError>>()?;
+            .collect::<Result<Vec<_>, DatabaseError>>()?;
         let files_data: Vec<_> = files_mmaps
             .iter()
             .map(|mmap| unsafe {
@@ -497,12 +497,12 @@ impl<D: Document> DB<D> {
     fn read_common_tokens(
         rotxn: &RoTxn,
         db_main: Database<Unspecified, Unspecified>,
-    ) -> Result<HashSet<Box<str>>, DbError> {
+    ) -> Result<HashSet<Box<str>>, DatabaseError> {
         let k = db_main
             .remap_types::<Str, ZeroCopyCodec<HashSet<Box<str>>>>()
             .get(rotxn, db_constants::KEY_COMMON_TOKENS)?
             .ok_or_else(|| {
-                DbError::KeyNotFound(
+                DatabaseError::KeyNotFound(
                     db_constants::KEY_COMMON_TOKENS.to_string(),
                     "main".to_string(),
                 )
@@ -515,7 +515,7 @@ impl<D: Document> DB<D> {
         &self,
         rwtxn: &mut RwTxn,
         common_tokens: &HashSet<Box<str>>,
-    ) -> Result<(), DbError> {
+    ) -> Result<(), DatabaseError> {
         log::debug!("Writing common tokens");
         let b = std::time::Instant::now();
         self.db_main
@@ -525,7 +525,7 @@ impl<D: Document> DB<D> {
         Ok(())
     }
 
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<(Self, HashSet<Box<str>>, Mmap), DbError> {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<(Self, HashSet<Box<str>>, Mmap), DatabaseError> {
         let path = path.as_ref();
         let env = unsafe {
             EnvOpenOptions::new()
@@ -538,7 +538,7 @@ impl<D: Document> DB<D> {
 
         let db_main = env
             .open_database(&rotxn, None)?
-            .ok_or_else(|| DbError::DatabaseError("main".to_string()))?;
+            .ok_or_else(|| DatabaseError::DatabaseError("main".to_string()))?;
 
         let db_doc_id_to_document = env
             .database_options()
@@ -547,12 +547,14 @@ impl<D: Document> DB<D> {
             .name(db_constants::DB_DOC_ID_TO_DOCUMENT)
             .open(&rotxn)?
             .ok_or_else(|| {
-                DbError::DatabaseError(db_constants::DB_DOC_ID_TO_DOCUMENT.to_string())
+                DatabaseError::DatabaseError(db_constants::DB_DOC_ID_TO_DOCUMENT.to_string())
             })?;
 
         let db_token_to_offsets = env
             .open_database(&rotxn, Some(db_constants::DB_TOKEN_TO_OFFSETS))?
-            .ok_or_else(|| DbError::DatabaseError(db_constants::DB_TOKEN_TO_OFFSETS.to_string()))?;
+            .ok_or_else(|| {
+                DatabaseError::DatabaseError(db_constants::DB_TOKEN_TO_OFFSETS.to_string())
+            })?;
 
         let common_tokens = Self::read_common_tokens(&rotxn, db_main)?;
 
@@ -593,7 +595,7 @@ impl<D: Document> DB<D> {
     > {
         #[inline(always)]
         fn check_before_recursion<'a, 'b, 'alloc, D: Document>(
-            me: &DB<D>,
+            me: &Db<D>,
             rotxn: &RoTxn,
             tokens: RefTokens<'a>,
             token_to_packed: &mut GxHashMap<RefTokens<'a>, BorrowRoaringishPacked<'b, Aligned>>,
@@ -611,7 +613,7 @@ impl<D: Document> DB<D> {
             let score = match token_to_packed.entry(tokens) {
                 Entry::Occupied(e) => e.get().len(),
                 Entry::Vacant(e) => {
-                    let packed = me.get_roaringish_packed(rotxn, &tokens[0], mmap)?;
+                    let packed = me.roaringish_packed(rotxn, &tokens[0], mmap)?;
                     let score = packed.len();
                     e.insert(packed);
 
@@ -625,7 +627,7 @@ impl<D: Document> DB<D> {
 
         #[allow(clippy::too_many_arguments)]
         fn inner_merge_and_minimize_tokens<'a, 'b, 'c, 'alloc, D: Document>(
-            me: &DB<D>,
+            me: &Db<D>,
             rotxn: &RoTxn,
             tokens: RefTokens<'a>,
             common_tokens: &HashSet<Box<str>>,
@@ -662,7 +664,7 @@ impl<D: Document> DB<D> {
                 let score = match token_to_packed.entry(tokens) {
                     Entry::Occupied(e) => e.get().len(),
                     Entry::Vacant(e) => {
-                        let packed = me.get_roaringish_packed(rotxn, tokens.tokens(), mmap)?;
+                        let packed = me.roaringish_packed(rotxn, tokens.tokens(), mmap)?;
                         let score = packed.len();
                         e.insert(packed);
                         score
@@ -731,7 +733,7 @@ impl<D: Document> DB<D> {
         // function makes some queries performance unpredictable
         #[inline(never)]
         fn no_common_tokens<'a, 'b, 'alloc, D: Document>(
-            me: &DB<D>,
+            me: &Db<D>,
             rotxn: &RoTxn,
             tokens: RefTokens<'a>,
             mmap: &'b Mmap,
@@ -747,7 +749,7 @@ impl<D: Document> DB<D> {
             let mut v = Vec::with_capacity(l);
 
             for token in tokens.ref_token_iter() {
-                let packed = me.get_roaringish_packed(rotxn, token.tokens(), mmap)?;
+                let packed = me.roaringish_packed(rotxn, token.tokens(), mmap)?;
                 token_to_packed.insert(token, packed);
                 v.push(token);
             }
@@ -797,7 +799,7 @@ impl<D: Document> DB<D> {
         }
     }
 
-    fn get_roaringish_packed_from_offset<'a>(
+    fn roaringish_packed_from_offset<'a>(
         offset: &ArchivedOffset,
         mmap: &'a Mmap,
     ) -> Result<BorrowRoaringishPacked<'a, Aligned>, SearchError> {
@@ -813,13 +815,13 @@ impl<D: Document> DB<D> {
         }
 
         mmap.advise_range(memmap2::Advice::Sequential, begin, len)
-            .map_err(|e| DbError::from(e))?;
+            .map_err(|e| DatabaseError::from(e))?;
 
         Ok(BorrowRoaringishPacked::new_raw(packed))
     }
 
     #[inline(always)]
-    pub fn get_roaringish_packed<'a>(
+    pub fn roaringish_packed<'a>(
         &self,
         rotxn: &RoTxn,
         token: &str,
@@ -828,9 +830,9 @@ impl<D: Document> DB<D> {
         let offset = self
             .db_token_to_offsets
             .get(rotxn, token)
-            .map_err(|e| DbError::from(e))?;
+            .map_err(|e| DatabaseError::from(e))?;
         match offset {
-            Some(offset) => Self::get_roaringish_packed_from_offset(offset, mmap),
+            Some(offset) => Self::roaringish_packed_from_offset(offset, mmap),
             None => Err(SearchError::TokenNotFound(token.to_string())),
         }
     }
@@ -855,11 +857,11 @@ impl<D: Document> DB<D> {
             return Err(SearchError::EmptyQuery);
         }
 
-        let rotxn = self.env.read_txn().map_err(|e| DbError::from(e))?;
+        let rotxn = self.env.read_txn().map_err(|e| DatabaseError::from(e))?;
         if tokens.len() == 1 {
             // this can't failt, we just checked
-            self.get_roaringish_packed(&rotxn, tokens.first().unwrap(), mmap)?
-                .get_doc_ids(stats);
+            self.roaringish_packed(&rotxn, tokens.first().unwrap(), mmap)?
+                .document_ids(stats);
         }
 
         let b = std::time::Instant::now();
@@ -878,7 +880,7 @@ impl<D: Document> DB<D> {
             return token_to_packed
                 .get(&final_tokens[0])
                 .ok_or_else(|| SearchError::TokenNotFound(final_tokens[0].tokens().to_string()))
-                .map(|p| p.get_doc_ids(stats));
+                .map(|p| p.document_ids(stats));
         }
 
         // at this point we know that we have at least
@@ -982,26 +984,26 @@ impl<D: Document> DB<D> {
             }
         }
 
-        Ok(result_borrow.get_doc_ids(stats))
+        Ok(result_borrow.document_ids(stats))
     }
 
     fn inner_get_archived_document<'a>(
         &self,
         rotxn: &'a RoTxn,
         doc_id: &u32,
-    ) -> Result<&'a D::Archived, GetDocumentError> {
+    ) -> Result<&'a D::Archived, DocumentError> {
         self.db_doc_id_to_document
             .get(rotxn, doc_id)
-            .map_err(|e| DbError::from(e))?
-            .ok_or(GetDocumentError::DocumentNotFound(*doc_id))
+            .map_err(|e| DatabaseError::from(e))?
+            .ok_or(DocumentError::DocumentNotFound(*doc_id))
     }
 
-    pub fn get_archived_documents(
+    pub fn archived_documents(
         &self,
         doc_ids: &[u32],
         cb: impl FnOnce(Vec<&D::Archived>),
-    ) -> Result<(), GetDocumentError> {
-        let rotxn = self.env.read_txn().map_err(|e| DbError::from(e))?;
+    ) -> Result<(), DocumentError> {
+        let rotxn = self.env.read_txn().map_err(|e| DatabaseError::from(e))?;
         let docs = doc_ids
             .into_iter()
             .map(|doc_id| self.inner_get_archived_document(&rotxn, doc_id))
@@ -1012,12 +1014,12 @@ impl<D: Document> DB<D> {
         Ok(())
     }
 
-    pub fn get_archived_document(
+    pub fn archived_document(
         &self,
         doc_id: u32,
         cb: impl FnOnce(&D::Archived),
-    ) -> Result<(), GetDocumentError> {
-        let rotxn = self.env.read_txn().map_err(|e| DbError::from(e))?;
+    ) -> Result<(), DocumentError> {
+        let rotxn = self.env.read_txn().map_err(|e| DatabaseError::from(e))?;
         let doc = self.inner_get_archived_document(&rotxn, &doc_id)?;
 
         cb(doc);
@@ -1025,28 +1027,28 @@ impl<D: Document> DB<D> {
         Ok(())
     }
 
-    pub fn get_documents(&self, doc_ids: &[u32]) -> Result<Vec<D>, GetDocumentError>
+    pub fn documents(&self, doc_ids: &[u32]) -> Result<Vec<D>, DocumentError>
     where
         <D as Archive>::Archived: Deserialize<D, Strategy<Pool, rkyv::rancor::Error>>,
     {
-        let rotxn = self.env.read_txn().map_err(|e| DbError::from(e))?;
+        let rotxn = self.env.read_txn().map_err(|e| DatabaseError::from(e))?;
         doc_ids
             .into_iter()
             .map(|doc_id| {
                 let archived = self.inner_get_archived_document(&rotxn, doc_id)?;
                 rkyv::deserialize::<D, rkyv::rancor::Error>(archived)
-                    .map_err(|e| GetDocumentError::DbError(DbError::from(e)))
+                    .map_err(|e| DocumentError::DatabaseError(DatabaseError::from(e)))
             })
             .collect::<Result<Vec<_>, _>>()
     }
 
-    pub fn get_document(&self, doc_id: u32) -> Result<D, GetDocumentError>
+    pub fn document(&self, doc_id: u32) -> Result<D, DocumentError>
     where
         <D as Archive>::Archived: Deserialize<D, Strategy<Pool, rkyv::rancor::Error>>,
     {
-        let rotxn = self.env.read_txn().map_err(|e| DbError::from(e))?;
+        let rotxn = self.env.read_txn().map_err(|e| DatabaseError::from(e))?;
         let archived = self.inner_get_archived_document(&rotxn, &doc_id)?;
         rkyv::deserialize::<D, rkyv::rancor::Error>(archived)
-            .map_err(|e| GetDocumentError::DbError(DbError::from(e)))
+            .map_err(|e| DocumentError::DatabaseError(DatabaseError::from(e)))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 /// Possible errors that can occur while interacting with the database.
 #[derive(Error, Debug)]
-pub enum DbError {
+pub enum DatabaseError {
     #[error("Io error: {0}")]
     IoError(#[from] std::io::Error),
 
@@ -23,7 +23,7 @@ pub enum DbError {
 #[derive(Error, Debug)]
 pub enum SearchError {
     #[error("Db error: {0}")]
-    DbError(#[from] DbError),
+    DatabaseError(#[from] DatabaseError),
 
     #[error("Searched query is empty")]
     EmptyQuery,
@@ -43,9 +43,9 @@ pub enum SearchError {
 
 /// Possible errors when trying to retrieve documents by their internal ID.
 #[derive(Error, Debug)]
-pub enum GetDocumentError {
+pub enum DocumentError {
     #[error("Db error: {0}")]
-    DbError(#[from] DbError),
+    DatabaseError(#[from] DatabaseError),
 
     #[error("Document with id `{0}` not found")]
     DocumentNotFound(u32),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -334,7 +334,7 @@ impl Indexer {
         };
         match common_tokens {
             CommonTokens::List(tokens) => tokens
-                .into_iter()
+                .iter()
                 .map(|t| t.to_string().clone().into_boxed_str())
                 .collect(),
             CommonTokens::FixedNumber(max) => {

--- a/src/roaringish/intersect/gallop_second.rs
+++ b/src/roaringish/intersect/gallop_second.rs
@@ -79,12 +79,12 @@ impl Intersect for GallopIntersectSecond {
                 }
             }
 
-            // // In micro benchmarking doing this version seems faster, but in the real
-            // // use case is slower
+            // // In micro benchmarking doing this version seems faster, but in
+            // the real // use case is slower
 
-            // let intersection = lhs_values.rotate_left(lhs_len as u32) & lsb_mask & rhs_values;
-            // if lhs_doc_id_group == rhs_doc_id_group && intersection > 0 {
-            //     unsafe {
+            // let intersection = lhs_values.rotate_left(lhs_len as u32) &
+            // lsb_mask & rhs_values; if lhs_doc_id_group ==
+            // rhs_doc_id_group && intersection > 0 {     unsafe {
             //         packed_result
             //         .get_unchecked_mut(*i)
             //         .write(lhs_doc_id_group | intersection as u64);

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -1,6 +1,8 @@
 use std::{collections::HashSet, path::Path};
 
-use crate::{db::Document, error::GetDocumentError, DbError, Intersection, SearchError, Stats, DB};
+use crate::{
+    db::Document, error::DocumentError, DatabaseError, Db, Intersection, SearchError, Stats,
+};
 use memmap2::Mmap;
 use rkyv::{de::Pool, rancor::Strategy, Archive, Deserialize};
 
@@ -13,51 +15,54 @@ impl<D: Document> SearchResult<'_, D> {
     }
 
     /// Returns the internal document IDs that matched the search query.
-    pub fn get_internal_document_ids(&self) -> Option<&[u32]> {
+    pub fn internal_document_ids(&self) -> Option<&[u32]> {
         self.0.as_ref().map(|p| p.as_slice()).ok()
     }
 
-    /// Gets the archived version of the documents that matched the search query.
+    /// Returns the archived version of the documents that matched the search
+    /// query.
     ///
     /// This avoids having to deserialize, but it's necessary to use a callback
     /// due to the lifetime of the transaction.
     ///
-    /// If you want the documents deserialized, use [Self::get_documents] instead.
-    pub fn get_archived_documents(
+    /// If you want the documents deserialized, use
+    /// [`documents()`](Self::documents) instead.
+    pub fn archived_documents(
         &self,
         cb: impl FnOnce(Vec<&D::Archived>),
-    ) -> Result<(), GetDocumentError> {
-        let Some(doc_ids) = self.get_internal_document_ids() else {
+    ) -> Result<(), DocumentError> {
+        let Some(doc_ids) = self.internal_document_ids() else {
             return Ok(());
         };
 
-        self.1.get_archived_documents(doc_ids, cb)
+        self.1.archived_documents(doc_ids, cb)
     }
 
-    /// Gets the deserialized version of the documents that matched the search query.
-    pub fn get_documents(&self) -> Result<Vec<D>, GetDocumentError>
+    /// Returns the deserialized version of the documents that matched the
+    /// search query.
+    pub fn documents(&self) -> Result<Vec<D>, DocumentError>
     where
         <D as Archive>::Archived: Deserialize<D, Strategy<Pool, rkyv::rancor::Error>>,
     {
-        let Some(doc_ids) = self.get_internal_document_ids() else {
+        let Some(doc_ids) = self.internal_document_ids() else {
             return Ok(Vec::new());
         };
 
-        self.1.get_documents(doc_ids)
+        self.1.documents(doc_ids)
     }
 }
 
 /// Object responsible for searching the database.
 pub struct Searcher<D: Document> {
-    db: DB<D>,
+    db: Db<D>,
     common_tokens: HashSet<Box<str>>,
     mmap: Mmap,
 }
 
 impl<D: Document> Searcher<D> {
     /// Create a new searcher object.
-    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, DbError> {
-        let (db, common_tokens, mmap) = DB::open(path)?;
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, DatabaseError> {
+        let (db, common_tokens, mmap) = Db::open(path)?;
         Ok(Self {
             db,
             common_tokens,
@@ -65,62 +70,68 @@ impl<D: Document> Searcher<D> {
         })
     }
 
-    /// Searches by the query `q`
-    pub fn search<I: Intersection>(&self, q: &str) -> SearchResult<D> {
+    /// Searches by `query`.
+    pub fn search<I: Intersection>(&self, query: &str) -> SearchResult<D> {
         let stats = Stats::default();
-        self.search_with_stats::<I>(q, &stats)
+        self.search_with_stats::<I>(query, &stats)
     }
 
-    /// Searches by the query `q`, allowing the user to pass a [Stats] object.
-    pub fn search_with_stats<I: Intersection>(&self, q: &str, stats: &Stats) -> SearchResult<D> {
+    /// Searches by the query `q`, allowing the user to pass a [`Stats`] object.
+    pub fn search_with_stats<I: Intersection>(
+        &self,
+        query: &str,
+        stats: &Stats,
+    ) -> SearchResult<D> {
         SearchResult(
             self.db
-                .search::<I>(q, stats, &self.common_tokens, &self.mmap),
+                .search::<I>(query, stats, &self.common_tokens, &self.mmap),
             self,
         )
     }
 
-    /// Gets the archived version of the documents.
+    /// Returns the archived version of the documents.
     ///
     /// This avoids having to deserialize, but it's necessary to use a callback
     /// due to the lifetime of the transaction.
     ///
-    /// If you want the documents deserialized, use [Self::get_documents] instead.
-    pub fn get_archived_documents(
+    /// If you want the documents deserialized, use
+    /// [`documents()`](Self::documents) instead.
+    pub fn archived_documents(
         &self,
-        doc_ids: &[u32],
+        document_ids: &[u32],
         cb: impl FnOnce(Vec<&D::Archived>),
-    ) -> Result<(), GetDocumentError> {
-        self.db.get_archived_documents(doc_ids, cb)
+    ) -> Result<(), DocumentError> {
+        self.db.archived_documents(document_ids, cb)
     }
 
-    /// Gets the archived version of a documents.
+    /// Returns the archived version of a documents.
     ///
     /// This avoids having to deserialize, but it's necessary to use a callback
     /// due to the lifetime of the transaction.
     ///
-    /// If you want the documents deserialized, use [Self::get_document] instead.
-    pub fn get_archived_document(
+    /// If you want the documents deserialized, use
+    /// [`document()`](Self::document) instead.
+    pub fn archived_document(
         &self,
-        doc_id: u32,
+        document_id: u32,
         cb: impl FnOnce(&D::Archived),
-    ) -> Result<(), GetDocumentError> {
-        self.db.get_archived_document(doc_id, cb)
+    ) -> Result<(), DocumentError> {
+        self.db.archived_document(document_id, cb)
     }
 
-    /// Gets the deserialized version of the documents.
-    pub fn get_documents(&self, doc_ids: &[u32]) -> Result<Vec<D>, GetDocumentError>
+    /// Returns the deserialized version of the documents.
+    pub fn documents(&self, document_ids: &[u32]) -> Result<Vec<D>, DocumentError>
     where
         <D as Archive>::Archived: Deserialize<D, Strategy<Pool, rkyv::rancor::Error>>,
     {
-        self.db.get_documents(doc_ids)
+        self.db.documents(document_ids)
     }
 
-    /// Gets the deserialized version of a documents.
-    pub fn get_document(&self, doc_id: u32) -> Result<D, GetDocumentError>
+    /// Returns the deserialized version of a documents.
+    pub fn document(&self, document_id: u32) -> Result<D, DocumentError>
     where
         <D as Archive>::Archived: Deserialize<D, Strategy<Pool, rkyv::rancor::Error>>,
     {
-        self.db.get_document(doc_id)
+        self.db.document(document_id)
     }
 }

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -8,6 +8,7 @@ use rkyv::{de::Pool, rancor::Strategy, Archive, Deserialize};
 
 /// Final result of a search operation.
 pub struct SearchResult<'a, D: Document>(pub Result<Vec<u32>, SearchError>, &'a Searcher<D>);
+
 impl<D: Document> SearchResult<'_, D> {
     /// Number of documents that matched the search query.
     pub fn len(&self) -> Option<usize> {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -3,7 +3,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering::Relaxed},
 };
 
-/// Time stats collected during search.
+/// Timing statistics collected during search.
 #[derive(Default)]
 pub struct Stats {
     /// Time spent during normalization and tokenization.
@@ -38,7 +38,7 @@ pub struct Stats {
     pub merge_phases_second_pass: AtomicU64,
 
     /// Time spent getting document ids.
-    pub get_doc_ids: AtomicU64,
+    pub document_ids: AtomicU64,
 
     /// Number of calls to the search function.
     pub iters: AtomicU64,
@@ -54,7 +54,7 @@ impl Debug for Stats {
             + self.second_intersect.load(Relaxed)
             + self.merge_phases_first_pass.load(Relaxed)
             + self.merge_phases_second_pass.load(Relaxed)
-            + self.get_doc_ids.load(Relaxed);
+            + self.document_ids.load(Relaxed);
         let sum = sum as f64;
 
         let normalize_tokenize = self.normalize_tokenize.load(Relaxed) as f64;
@@ -71,7 +71,7 @@ impl Debug for Stats {
         let second_intersect_gallop = self.second_intersect_gallop.load(Relaxed) as f64;
         let merge_phases_first_pass = self.merge_phases_first_pass.load(Relaxed) as f64;
         let merge_phases_second_pass = self.merge_phases_second_pass.load(Relaxed) as f64;
-        let get_doc_ids = self.get_doc_ids.load(Relaxed) as f64;
+        let document_ids = self.document_ids.load(Relaxed) as f64;
         let iters = self.iters.load(Relaxed) as f64;
 
         let per_normalize_tokenize = normalize_tokenize / sum * 100f64;
@@ -82,7 +82,7 @@ impl Debug for Stats {
         let per_second_intersect = second_intersect / sum * 100f64;
         let per_merge_phases_first_pass = merge_phases_first_pass / sum * 100f64;
         let per_merge_phases_second_pass = merge_phases_second_pass / sum * 100f64;
-        let per_get_doc_ids = get_doc_ids / sum * 100f64;
+        let per_document_ids = document_ids / sum * 100f64;
 
         f.debug_struct("Stats")
             .field(
@@ -198,11 +198,11 @@ impl Debug for Stats {
                 ),
             )
             .field(
-                "get_doc_ids",
+                "document_ids",
                 &format_args!(
-                    "               ({:08.3}ms, {:08.3}us/iter, {per_get_doc_ids:06.3}%)",
-                    get_doc_ids / 1000f64,
-                    get_doc_ids / iters,
+                    "               ({:08.3}ms, {:08.3}us/iter, {per_document_ids:06.3}%)",
+                    document_ids / 1000f64,
+                    document_ids / iters,
                 ),
             )
             .finish()


### PR DESCRIPTION
These are almost entirely automatic fixes that `cargo clippy --fix` yielded.

As a result of those the next `clippy` run indentified some superfluous lifetimes that I removed.

Left is `SeachResult::len()`. This popped up because SearchResult misses `is_empty()`, the companion of `len()` that `clippy` laments should always be implemented.

However, a Rust user would be suprised that `len()` returns Option<usize> and not `usize`.

I see two possibilities:

* Rename `SearchResult::len()` to `try_len()` to make it obvious that this returns an `Option` (or could even be `Result` and return the original `Err`) and keep the signature.

* Make it return an `usize`, i.e. map a possible encountered `Err`/`None` inside the function to the `0usize` return value.
  
   In this case also add:
   
   ```rust
   fn is_empty(&self) -> bool {
       self.len == 0
   }
   ```

